### PR TITLE
Fix HCI book link in jekyll.mdx

### DIFF
--- a/data/blog/jekyll.mdx
+++ b/data/blog/jekyll.mdx
@@ -77,7 +77,7 @@ This division of power must be sought in the production of increasingly capable 
 
 A division of power is not what my colleagues in artificial intelligence are [calling](https://futureoflife.org/open-letter/pause-giant-ai-experiments/) for when they advocate [to  control](https://www.theguardian.com/commentisfree/2023/apr/02/ai-much-to-offer-humanity-could-wreak-terrible-harm-must-be-controlled) AI. A highly publicised joint statement reads, *"Powerful AI systems should be developed only once we are confident that their effects will be positive and their risks will be manageable"* [(From "Pause Giant AI Experiments: An Open Letter")](https://futureoflife.org/open-letter/pause-giant-ai-experiments/). The implication is that we just need time to figure out how to safely give machines power. This is a mistake. Time will not cure the "power problem." **Immense power will never be managed.** That is not how the universe works.
 
-Provisioning power to machine systems is a marker of bad safety engineering. Machines do not need power. Machines should [empower people](/hcaibook.html) to live and act in the world where no individual machine -- or human -- has the power to bring about unbounded harms.
+Provisioning power to machine systems is a marker of bad safety engineering. Machines do not need power. Machines should [empower people](/blog/hcai) to live and act in the world where no individual machine -- or human -- has the power to bring about unbounded harms.
 
 We cannot engineer away the possibility of an artificial Hyde, but we can make a society safe for its duality.
 


### PR DESCRIPTION
The link for "empower people"(hcaibook.html) leads to 404. Did it intend to point to the book review for "Human Centered AI"?